### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/lib/db.rkt
+++ b/lib/db.rkt
@@ -4,10 +4,17 @@
          racket/serialize
          racket/contract
          racket/local
-         unstable/bytes
          (planet jaymccarthy/mongodb))
 
 (struct db (m d heap-mc tree-mc))
+
+(define (read/bytes bs)
+  (read (open-input-bytes bs)))
+
+(define (write/bytes v)
+  (define by (open-output-bytes))
+  (write v by)
+  (get-output-bytes by))
 
 (define (ensure-mongo-collection d c #:init? init?)
   (if init?


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

Moves the contents of `unstable/bytes` to this package.

This change is compatible with Racket 6.2.
